### PR TITLE
make notice $identifier track between big_endian and big_endian_specific

### DIFF
--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -98,7 +98,7 @@ event dce_rpc_message(c: connection, is_orig: bool, fid: count, ptype_id: count,
 		    $note=ExploitSuccess,
 		    $msg=fmt("%s exploited %s", c$id$orig_h, c$id$resp_h),
 		    $sub="Found via big_endian_specific (in dce_rpc_message)",
-		    $identifier=cat(c$id$orig_h, c$id$resp_h)]);
+		    $identifier=cat(c$id$orig_h, c$id$resp_h, "big_endian_specific")]);
 	}
 	if ( big_endian in pkt$data && correct_frag_length(pkt$data, big_endian) &&
 	    sec_addr_is_zero(pkt$data, big_endian) ) {
@@ -106,6 +106,6 @@ event dce_rpc_message(c: connection, is_orig: bool, fid: count, ptype_id: count,
 		    $note=ExploitSuccess,
 		    $msg=fmt("%s exploited %s", c$id$orig_h, c$id$resp_h),
 		    $sub="Found via big_endian (in dce_rpc_message)",
-		    $identifier=cat(c$id$orig_h, c$id$resp_h)]);
+		    $identifier=cat(c$id$orig_h, c$id$resp_h, "big_endian")]);
 	}
 }


### PR DESCRIPTION
fixes #1

root cause is those two notices shared notice `$identifiers` and this version of Zeek fixed a race condition in notice suppression.